### PR TITLE
adding support for 5.6 from dotdeb repos for debian

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -148,6 +148,9 @@ module Opscode
             '7' => {
               '5.5' => {
                 'package_name' => 'mysql-server-5.5'
+              },
+              '5.6' => {
+                'package_name' => 'mysql-server-5.6' # apt-repo from dotdeb
               }
             },
             'jessie/sid' => {


### PR DESCRIPTION
This is a partial backport of this https://github.com/chef-cookbooks/mysql/commit/7386b6072d2e9bd78543fd85e5ed219b25e32786
